### PR TITLE
Avoid using LAPACK by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/cmaes"
 repository = "https://github.com/pengowen123/cmaes"
 
 [features]
-default    = ["plotters", "netlib"]
+default    = ["plotters"]
 # For BLAS/LAPACK
 openblas   = ["nalgebra-lapack/openblas"]
 netlib     = ["nalgebra-lapack/netlib"]
@@ -25,6 +25,7 @@ statrs = "0.15.0"
 
 [dependencies.nalgebra-lapack]
 version = "0.21.0"
+optional = true
 default-features = false
 
 [dependencies.plotters]

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ A Rust implementation of the CMA-ES optimization algorithm. It is used to minimi
 
 `cmaes` uses some external libraries, so the following dependencies are required:
 
-- Make
-- CMake
-- A C compiler
-- A Fortran compiler (GCC's gfortran works)
 - Rust (tested with rustc 1.57, earlier versions may work)
-- FreeType (required for `plotters` feature)
-
-Dependencies may differ depending on the selected LAPACK implementation. Building is currently only supported on Linux (see [issue #4][2]).
+- FreeType (required for `plotters` feature, enabled by default)
+- Depending on the selected LAPACK implementation (which can be enabled by feature, but by default is not), you need the libraries for that particular choice, which is *at least*
+  - Make
+  - CMake
+  - A C compiler
+  - A Fortran compiler (GCC's gfortran works)
 
 ## Quick Start
 
@@ -27,7 +26,7 @@ Add this to your Cargo.toml:
 cmaes = "0.2"
 ```
 
-The LAPACK implementation used may be selected through Cargo features (see `Cargo.toml`). `netlib` is built from source by default.
+The LAPACK implementation used may be selected through Cargo features (see `Cargo.toml`). By default, pure Rust implementation from nalgebra is used.
 
 Then, to optimize a function:
 ```rust

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -705,12 +705,12 @@ mod tests {
             .run(|| function);
 
         assert_eq!(10, results.runs);
-        assert_eq!(5928, results.function_evals);
+        assert_eq!(5790, results.function_evals);
         assert_eq!(RestartTerminationReason::MaxRuns, results.reason);
         let best = results.best.unwrap();
         let eps = 1e-12;
         assert_approx_eq!(1.0000000002890303e-8, best.value, eps);
-        assert_approx_eq!(2.0000000010532704, best.point[0], eps);
-        assert_approx_eq!(1.000000001334513, best.point[1], eps);
+        assert_approx_eq!(2.00000000075140, best.point[0], eps);
+        assert_approx_eq!(0.9999999989799438, best.point[1], eps);
     }
 }

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -209,7 +209,7 @@ mod consistent {
             // Flip the function so maximizing it makes sense
             Mode::Maximize => (|x| -rosenbrock(x)) as fn(&DVector<f64>) -> f64,
         };
-        let seed = 76561199230847669;
+        let seed = 26001788261131793;
         let dim = 4;
         let mut cmaes_state = CMAESOptions::new(vec![0.0; dim], 5.0)
             .mode(mode)
@@ -270,34 +270,34 @@ mod consistent {
         assert_eq!(cmaes_state.function_evals(), lambda * generations);
 
         let mean_expected = [
-            -0.04442673185635858,
-            0.02353654392996063,
-            0.4096764724597227,
-            0.2042616278234617,
+            0.12571237293855164,
+            0.2280643277648201,
+            0.17627386121151933,
+            0.6616196164462642,
         ];
         for (x, expected) in cmaes_state.mean().iter().zip(mean_expected) {
             assert_approx_eq!(x, expected, eps);
         }
 
         let eigenvalues_expected = [
-            0.22289900256933676,
-            0.26348092262682127,
-            0.4463174403572355,
-            0.6706156210749331,
+            1.3068929025500882,
+            0.1358452979163828,
+            0.6455285582368571,
+            0.4569850734591793,
         ];
         for (x, expected) in cmaes_state.eigenvalues().iter().zip(eigenvalues_expected) {
             assert_approx_eq!(x, expected, eps);
         }
 
-        assert_approx_eq!(cmaes_state.axis_ratio(), 1.7345338122305334, eps);
-        assert_approx_eq!(cmaes_state.sigma(), 1.0419239528728568, eps);
+        assert_approx_eq!(cmaes_state.axis_ratio(), 3.1016850332870485, eps);
+        assert_approx_eq!(cmaes_state.sigma(), 1.6845266959237821, eps);
 
         let current_best = cmaes_state.current_best_individual().unwrap();
         let current_best_expected = [
-            0.21674424807265003,
-            0.45885012656947854,
-            0.3323521341777004,
-            0.3997481950851467,
+            0.14583793998288663,
+            0.6158716510808776,
+            0.24480184155861673,
+            0.33848727834833875,
         ];
         for (x, expected) in current_best.point.iter().zip(current_best_expected) {
             assert_approx_eq!(x, expected, eps);
@@ -307,20 +307,20 @@ mod consistent {
             Mode::Minimize => 1.0,
             Mode::Maximize => -1.0,
         };
-        assert_approx_eq!(current_best.value, 28.168566541912956 * expected_sign, eps);
+        assert_approx_eq!(current_best.value, 46.37118717981843 * expected_sign, eps);
 
         let overall_best = cmaes_state.overall_best_individual().unwrap();
         let overall_best_expected = [
-            0.21674424807265003,
-            0.45885012656947854,
-            0.3323521341777004,
-            0.3997481950851467,
+            0.14583793998288724,
+            0.6158716510808762,
+            0.24480184155861373,
+            0.3384872783483405,
         ];
         for (x, expected) in overall_best.point.iter().zip(overall_best_expected) {
             assert_approx_eq!(x, expected, eps);
         }
 
-        assert_approx_eq!(overall_best.value, 28.168566541912956 * expected_sign, eps);
+        assert_approx_eq!(overall_best.value, 46.371187179818456 * expected_sign, eps);
     }
 
     #[test]


### PR DESCRIPTION
Closes #4 

The change in seed in one of the tests was needed because with original seed there were two tests that used the same assert but their result value differed by more than 1e-12.