### PR TITLE
Restarter: Make the default CMAESOptions adjustable

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -28,7 +28,7 @@ use crate::CMAES;
 ///     .build(function)
 ///     .unwrap();
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CMAESOptions {
     /// The mode to use when optimizing the objective function. Default value is [`Mode::Minimize`].
     pub mode: Mode,

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -133,6 +133,8 @@ pub struct Restarter {
     mode: Mode,
     /// Whether to perform state updates in parallel
     parallel_update: bool,
+    /// The default options to use for a fresh start.
+    default_options: CMAESOptions,
     /// The range in which to generate the initial mean for each run
     search_range: RangeInclusive<f64>,
     /// The target objective function value
@@ -172,6 +174,7 @@ impl Restarter {
                 dimensions: options.dimensions,
                 mode: options.mode,
                 parallel_update: options.parallel_update,
+                default_options: options.default_options,
                 search_range: options.search_range,
                 fun_target: options.fun_target,
                 max_function_evals: options.max_function_evals,
@@ -314,7 +317,8 @@ impl Restarter {
             let seed = self.rng.gen();
 
             // Apply default configuration (may be overridden by individual restart strategies)
-            let mut options = CMAESOptions::new(initial_mean, DEFAULT_INITIAL_STEP_SIZE)
+            let mut options = self.default_options.clone()
+                .initial_mean(initial_mean)
                 .mode(self.mode)
                 .parallel_update(self.parallel_update)
                 .seed(seed);

--- a/src/restart/options.rs
+++ b/src/restart/options.rs
@@ -4,8 +4,9 @@
 use std::ops::RangeInclusive;
 use std::time::Duration;
 
-use super::{RestartStrategy, Restarter};
-use crate::Mode;
+
+use super::{DEFAULT_INITIAL_STEP_SIZE, RestartStrategy, Restarter};
+use crate::{CMAESOptions, Mode};
 
 /// Represents invalid options for a `Restarter`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,6 +54,8 @@ pub struct RestartOptions {
     /// floating point errors this option is generally incompatible with setting a fixed
     /// [`seed`][Self::seed] for deterministic runs.
     pub parallel_update: bool,
+    /// The default options to use. Will be cloned and adjusted for each restart.
+    pub default_options: CMAESOptions,
     /// The range in which to generate the initial mean for each run. The same range is used in each
     /// dimension (i.e., `[A, B]^N`). To scale the search range separately in each dimension, the
     /// appropriate transformation should be made to the objective function itself using
@@ -97,6 +100,7 @@ impl RestartOptions {
             dimensions,
             mode: Mode::Minimize,
             parallel_update: false,
+            default_options: CMAESOptions::new(vec![0.0; dimensions], DEFAULT_INITIAL_STEP_SIZE),
             search_range,
             fun_target: None,
             max_function_evals: None,
@@ -117,6 +121,12 @@ impl RestartOptions {
     /// Sets whether to perform state updates in parallel.
     pub fn parallel_update(mut self, parallel_update: bool) -> Self {
         self.parallel_update = parallel_update;
+        self
+    }
+
+    /// Sets the default options
+    pub fn default_options(mut self, options: CMAESOptions) -> Self {
+        self.default_options = options;
         self
     }
 


### PR DESCRIPTION
Makes the default CMAESOptions used for restart strategies adjustable.